### PR TITLE
Add React 17 to peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22882,8 +22882,8 @@
         "prettier": "^2.7.1"
       },
       "peerDependencies": {
-        "react": "^18.1.0",
-        "react-dom": "^18.1.0"
+        "react": "^18.X.X || 17.X.X",
+        "react-dom": "^18.1.0 || 17.X.X"
       }
     },
     "packages/wallet-tester": {

--- a/packages/aptos-wallet-adapter/package.json
+++ b/packages/aptos-wallet-adapter/package.json
@@ -11,8 +11,8 @@
     "build": "rm -rf dist; tsc -p tsconfig.json"
   },
   "peerDependencies": {
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0"
+    "react": "^18.X.X || 17.X.X",
+    "react-dom": "^18.1.0 || 17.X.X"
   },
   "devDependencies": {
     "eslint-config-airbnb-typescript": "^17.0.0",


### PR DESCRIPTION
## Description
There are many project still use React@17.X.X so it would be best if the package supports both version 18 and version 17 of React library otherwise it would lead to dependency conflicts.