### PR TITLE
feat: add `signMessage`

### DIFF
--- a/packages/aptos-wallet-adapter/src/WalletAdapters/AptosWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/AptosWallet.ts
@@ -23,6 +23,7 @@ interface IAptosWallet {
   isConnected: () => Promise<boolean>;
   signAndSubmitTransaction(transaction: any): Promise<{ hash: HexEncodedBytes }>;
   signTransaction(transaction: any): Promise<SubmitTransactionRequest>;
+  signMessage(message: string): Promise<string>;
   disconnect(): Promise<void>;
 }
 
@@ -188,6 +189,24 @@ export class AptosWalletAdapter extends BaseWalletAdapter {
         return response;
       } else {
         throw new Error('Transaction failed');
+      }
+    } catch (error: any) {
+      const errMsg = error.message;
+      this.emit('error', new WalletSignTransactionError(errMsg));
+      throw error;
+    }
+  }
+
+  async signMessage(message: string): Promise<string> {
+    try {
+      const wallet = this._wallet;
+      const provider = this._provider || window.aptos;
+      if (!wallet || !provider) throw new WalletNotConnectedError();
+      const response = await provider?.signMessage(message);
+      if (response) {
+        return response;
+      } else {
+        throw new Error('Sign Message failed');
       }
     } catch (error: any) {
       const errMsg = error.message;

--- a/packages/aptos-wallet-adapter/src/WalletAdapters/BaseAdapter.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/BaseAdapter.ts
@@ -72,6 +72,7 @@ export interface WalletAdapterProps<Name extends string = string> {
     transaction: TransactionPayload,
     options?: any
   ): Promise<SubmitTransactionRequest>;
+  signMessage(message: string): Promise<string>;
 }
 
 export type WalletAdapter<Name extends string = string> = WalletAdapterProps<Name> &
@@ -104,6 +105,8 @@ export abstract class BaseWalletAdapter
   ): Promise<{ hash: HexEncodedBytes }>;
 
   abstract signTransaction(transaction: TransactionPayload): Promise<SubmitTransactionRequest>;
+
+  abstract signMessage(message: string): Promise<string>;
 }
 
 export function scopePollingDetectionStrategy(detect: () => boolean): void {

--- a/packages/aptos-wallet-adapter/src/WalletAdapters/FewchaWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/FewchaWallet.ts
@@ -210,4 +210,22 @@ export class FewchaWalletAdapter extends BaseWalletAdapter {
       throw error;
     }
   }
+
+  async signMessage(message: string): Promise<string> {
+    try {
+      const wallet = this._wallet;
+      const provider = this._provider || window.fewcha;
+      if (!wallet || !provider) throw new WalletNotConnectedError();
+      const response = await provider?.signMessage(message);
+      if (response) {
+        return response.data;
+      } else {
+        throw new Error('Sign Message failed');
+      }
+    } catch (error: any) {
+      const errMsg = error.message;
+      this.emit('error', new WalletSignTransactionError(errMsg));
+      throw error;
+    }
+  }
 }

--- a/packages/aptos-wallet-adapter/src/WalletAdapters/HippoExtensionWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/HippoExtensionWallet.ts
@@ -28,6 +28,7 @@ interface IHippoWallet {
   isConnected: () => Promise<boolean>;
   signAndSubmitTransaction(transaction: any): Promise<any>;
   signTransaction(transaction: any): Promise<void>;
+  signMessage(message: string): Promise<string>;
   disconnect(): Promise<void>;
 }
 
@@ -199,6 +200,24 @@ export class HippoExtensionWalletAdapter extends BaseWalletAdapter {
       }
     } catch (error: any) {
       this.emit('error', error);
+      throw error;
+    }
+  }
+
+  async signMessage(message: string): Promise<string> {
+    try {
+      const wallet = this._wallet;
+      const provider = this._provider || window.hippoWallet;
+      if (!wallet || !provider) throw new WalletNotConnectedError();
+      const response = await provider?.signMessage(message);
+      if (response) {
+        return response;
+      } else {
+        throw new Error('Sign Message failed');
+      }
+    } catch (error: any) {
+      const errMsg = error.message;
+      this.emit('error', new WalletSignTransactionError(errMsg));
       throw error;
     }
   }

--- a/packages/aptos-wallet-adapter/src/WalletAdapters/HippoWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/HippoWallet.ts
@@ -196,6 +196,32 @@ export class HippoWalletAdapter extends BaseWalletAdapter {
     }
   }
 
+  async signMessage(message: string): Promise<string> {
+    try {
+      const request = new URLSearchParams({
+        request: JSON.stringify({
+          method: 'signMessage',
+          payload: message
+        }),
+        origin: window.location.origin
+      }).toString();
+      const popup = window.open(
+        `${WEBWALLET_URL}?${request}`,
+        'Transaction Confirmation',
+        'scrollbars=no,resizable=no,status=no,location=no,toolbar=no,menubar=no,width=440,height=700'
+      );
+      if (!popup) throw new WalletNotConnectedError();
+      const promise = await new Promise((resolve, reject) => {
+        this.once('success', resolve);
+        this.once('error', reject);
+      });
+      return promise as string;
+    } catch (error: any) {
+      this.emit('error', error);
+      throw error;
+    }
+  }
+
   private _beforeUnload = (): void => {
     void this.disconnect();
   };

--- a/packages/aptos-wallet-adapter/src/WalletAdapters/MartianWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/MartianWallet.ts
@@ -38,6 +38,7 @@ interface IMartianWallet {
   generateTransaction(sender: MaybeHexString, payload: any): Promise<any>;
   signAndSubmitTransaction(transaction: TransactionPayload): Promise<HexEncodedBytes>;
   signTransaction(transaction: TransactionPayload): Promise<HexEncodedBytes>;
+  signMessage(message: string): Promise<string>;
   disconnect(): Promise<void>;
 }
 
@@ -214,6 +215,24 @@ export class MartianWalletAdapter extends BaseWalletAdapter {
       return { hash: response };
     } catch (error: any) {
       this.emit('error', new Error(error));
+      throw error;
+    }
+  }
+
+  async signMessage(message: string): Promise<string> {
+    try {
+      const wallet = this._wallet;
+      const provider = this._provider || window.martian;
+      if (!wallet || !provider) throw new WalletNotConnectedError();
+      const response = await provider?.signMessage(message);
+      if (response) {
+        return response;
+      } else {
+        throw new Error('Sign Message failed');
+      }
+    } catch (error: any) {
+      const errMsg = error.message;
+      this.emit('error', new WalletSignTransactionError(errMsg));
       throw error;
     }
   }

--- a/packages/aptos-wallet-adapter/src/WalletAdapters/PontemWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/PontemWallet.ts
@@ -45,6 +45,7 @@ interface IPontemWallet {
     };
   }>;
   // signTransaction(transaction: TransactionPayload): Promise<HexEncodedBytes>;
+  signMessage(message: string): Promise<string>;
   disconnect(): Promise<void>;
 }
 
@@ -223,6 +224,24 @@ export class PontemWalletAdapter extends BaseWalletAdapter {
       return { hash: response.result.hash };
     } catch (error: any) {
       this.emit('error', new Error(error.error.message));
+      throw error;
+    }
+  }
+
+  async signMessage(message: string): Promise<string> {
+    try {
+      const wallet = this._wallet;
+      const provider = this._provider || window.pontem;
+      if (!wallet || !provider) throw new WalletNotConnectedError();
+      const response = await provider?.signMessage(message);
+      if (response) {
+        return response;
+      } else {
+        throw new Error('Sign Message failed');
+      }
+    } catch (error: any) {
+      const errMsg = error.message;
+      this.emit('error', new WalletSignTransactionError(errMsg));
       throw error;
     }
   }

--- a/packages/aptos-wallet-adapter/src/WalletAdapters/SpikaWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/SpikaWallet.ts
@@ -23,6 +23,7 @@ interface ISpikaWallet {
   isConnected: () => Promise<boolean>;
   signAndSubmitTransaction(transaction: any): Promise<{ hash: HexEncodedBytes }>;
   signTransaction(transaction: any): Promise<SubmitTransactionRequest>;
+  signMessage(message: string): Promise<string>;
   disconnect(): Promise<void>;
 }
 
@@ -198,6 +199,24 @@ export class SpikaWalletAdapter extends BaseWalletAdapter {
         return response;
       } else {
         throw new Error('Transaction failed');
+      }
+    } catch (error: any) {
+      const errMsg = error.message;
+      this.emit('error', new WalletSignTransactionError(errMsg));
+      throw error;
+    }
+  }
+
+  async signMessage(message: string): Promise<string> {
+    try {
+      const wallet = this._wallet;
+      const provider = this._provider || window.spika;
+      if (!wallet || !provider) throw new WalletNotConnectedError();
+      const response = await provider?.signMessage(message);
+      if (response) {
+        return response;
+      } else {
+        throw new Error('Sign Message failed');
       }
     } catch (error: any) {
       const errMsg = error.message;

--- a/packages/aptos-wallet-adapter/src/WalletProviders/WalletProvider.tsx
+++ b/packages/aptos-wallet-adapter/src/WalletProviders/WalletProvider.tsx
@@ -237,6 +237,15 @@ export const WalletProvider: FC<WalletProviderProps> = ({
     [adapter, handleError, connected]
   );
 
+  const signMessage = useCallback(
+    async (message: string) => {
+      if (!adapter) throw handleError(new WalletNotSelectedError());
+      if (!connected) throw handleError(new WalletNotConnectedError());
+      return adapter.signMessage(message);
+    },
+    [adapter, handleError, connected]
+  );
+
   return (
     <WalletContext.Provider
       value={{
@@ -250,7 +259,8 @@ export const WalletProvider: FC<WalletProviderProps> = ({
         connect,
         disconnect,
         signAndSubmitTransaction,
-        signTransaction
+        signTransaction,
+        signMessage
       }}>
       {children}
     </WalletContext.Provider>

--- a/packages/aptos-wallet-adapter/src/WalletProviders/useWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletProviders/useWallet.ts
@@ -29,6 +29,7 @@ export interface WalletContextState {
   disconnect(): Promise<void>;
   signAndSubmitTransaction(transaction: TransactionPayload): Promise<{ hash: HexEncodedBytes }>;
   signTransaction(transaction: TransactionPayload): Promise<SubmitTransactionRequest>;
+  signMessage(message: string): Promise<string>;
 }
 
 const DEFAULT_CONTEXT = {

--- a/packages/wallet-tester/src/pages/index.tsx
+++ b/packages/wallet-tester/src/pages/index.tsx
@@ -11,6 +11,7 @@ import { AptosAccount } from 'aptos';
 const MainPage = () => {
   const [txLoading, setTxLoading] = useState(false);
   const [txLinks, setTxLinks] = useState<string[]>([]);
+  const [signature, setSignature] = useState<string>('');
   const {
     connect,
     disconnect,
@@ -20,7 +21,8 @@ const MainPage = () => {
     connecting,
     connected,
     disconnecting,
-    wallet: currentWallet
+    wallet: currentWallet,
+    signMessage
   } = useWallet();
 
   const renderWalletConnectorGroup = () => {
@@ -80,6 +82,22 @@ const MainPage = () => {
     ));
   };
 
+  const signMess = async () => {
+    try {
+      setTxLoading(true);
+      if (account?.publicKey) {
+        const addressKey = account?.publicKey?.toString() || '';
+        const signedMessage = (await signMessage(`Hello from account ${addressKey}`)) as any;
+        setSignature(signedMessage.signedMessage.toString());
+        alert(`Signature is, ${signedMessage.signedMessage}`);
+      }
+    } catch (err: any) {
+      console.log('tx error: ', err.msg);
+    } finally {
+      setTxLoading(false);
+    }
+  };
+
   const renderContent = () => {
     if (connecting || disconnecting) {
       return <Spin indicator={<LoadingOutlined style={{ fontSize: 48 }} spin />} />;
@@ -96,6 +114,10 @@ const MainPage = () => {
           <strong>
             AuthKey: <div id="authKey">{account?.authKey?.toString()}</div>
           </strong>
+          <strong>Message to Sign : Hello from account {account?.publicKey?.toString()}</strong>
+          <Button id="transferBtn" onClick={() => signMess()} loading={txLoading}>
+            Sign Message
+          </Button>
           <Button id="transferBtn" onClick={() => transferToken()} loading={txLoading}>
             Transfer Token
           </Button>


### PR DESCRIPTION
Added a `signMessage` to sign plain string messages.

Also added a example [here](packages/wallet-tester/src/pages/index.tsx) to demonstrate the same.

PS. Tested it with aptos petra wallet and it works. Please let me know or help with other e2e tests.