### PR TITLE
Add error response process for Aptos wallets methods

### DIFF
--- a/packages/aptos-wallet-adapter/src/WalletAdapters/AptosWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/AptosWallet.ts
@@ -17,12 +17,20 @@ import {
   WalletReadyState
 } from './BaseAdapter';
 
+interface IApotsErrorResult {
+  code: number;
+  name: string;
+  message: string;
+}
+
 interface IAptosWallet {
   connect: () => Promise<{ address: string; publicKey: string }>;
   account: () => Promise<string>;
   isConnected: () => Promise<boolean>;
-  signAndSubmitTransaction(transaction: any): Promise<{ hash: HexEncodedBytes }>;
-  signTransaction(transaction: any): Promise<SubmitTransactionRequest>;
+  signAndSubmitTransaction(
+    transaction: any
+  ): Promise<{ hash: HexEncodedBytes } | IApotsErrorResult>;
+  signTransaction(transaction: any): Promise<SubmitTransactionRequest | IApotsErrorResult>;
   disconnect(): Promise<void>;
 }
 
@@ -162,12 +170,11 @@ export class AptosWalletAdapter extends BaseWalletAdapter {
       const provider = this._provider || window.aptos;
       if (!wallet || !provider) throw new WalletNotConnectedError();
 
-      const response = await provider?.signTransaction(transaction);
-      if (response) {
-        return response;
-      } else {
-        throw new Error('Sign Transaction failed');
+      const response = await provider.signTransaction(transaction);
+      if ((response as IApotsErrorResult).code) {
+        throw new Error((response as IApotsErrorResult).message);
       }
+      return response as SubmitTransactionRequest;
     } catch (error: any) {
       const errMsg = error.message;
       this.emit('error', new WalletSignTransactionError(errMsg));
@@ -183,12 +190,11 @@ export class AptosWalletAdapter extends BaseWalletAdapter {
       const provider = this._provider || window.aptos;
       if (!wallet || !provider) throw new WalletNotConnectedError();
 
-      const response = await provider?.signAndSubmitTransaction(transaction);
-      if (response) {
-        return response;
-      } else {
-        throw new Error('Transaction failed');
+      const response = await provider.signAndSubmitTransaction(transaction);
+      if ((response as IApotsErrorResult).code) {
+        throw new Error((response as IApotsErrorResult).message);
       }
+      return response as { hash: HexEncodedBytes };
     } catch (error: any) {
       const errMsg = error.message;
       this.emit('error', new WalletSignTransactionError(errMsg));


### PR DESCRIPTION
Aptos wallet would return an error response when error occurs instead of throwing an exception for methods signTransaction and signAndSubmitTransaction.