### PR TITLE
fix: typo for name, select before connecting

### DIFF
--- a/packages/aptos-wallet-adapter/src/WalletProviders/WalletProvider.tsx
+++ b/packages/aptos-wallet-adapter/src/WalletProviders/WalletProvider.tsx
@@ -203,7 +203,7 @@ export const WalletProvider: FC<WalletProviderProps> = ({
   const connect = useCallback(
     async (walletName: WalletName) => {
       if (isConnecting.current || isDisconnecting.current || connected) return;
-      if (!name) {
+      if (!walletName) {
         setName(walletName);
       } else {
         if (!adapter) throw handleError(new WalletNotSelectedError());

--- a/packages/wallet-nextjs/pages/index.tsx
+++ b/packages/wallet-nextjs/pages/index.tsx
@@ -22,6 +22,7 @@ const MainPage = () => {
     wallets,
     signAndSubmitTransaction,
     connecting,
+    select,
     connected,
     disconnecting,
     wallet: currentWallet,
@@ -34,6 +35,7 @@ const MainPage = () => {
       return (
         <Button
           onClick={() => {
+            select(option.name)
             connect(option.name);
           }}
           id={option.name.split(' ').join('_')}

--- a/packages/wallet-tester/src/pages/index.tsx
+++ b/packages/wallet-tester/src/pages/index.tsx
@@ -25,6 +25,7 @@ const MainPage = () => {
     signAndSubmitTransaction,
     connecting,
     connected,
+    select,
     disconnecting,
     wallet: currentWallet,
     signMessage,
@@ -37,6 +38,7 @@ const MainPage = () => {
       return (
         <Button
           onClick={() => {
+            select(option.name);
             connect(option.name);
           }}
           id={option.name.split(' ').join('_')}


### PR DESCRIPTION
- Typo `walletName` instead of `name`
- `select()` to be used before connecting using `connect`

PS: Thanks for the auto connect, Works perfectly after these changes.