### PR TITLE
Fix for Petra prompting to reconnect on connect()

### DIFF
--- a/packages/aptos-wallet-adapter/src/WalletAdapters/PetraWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/PetraWallet.ts
@@ -154,11 +154,6 @@ export class AptosWalletAdapter extends BaseWalletAdapter {
       this._connecting = true;
 
       const provider = this._provider || window.aptos;
-      const isConnected = await this._provider?.isConnected();
-      if (isConnected === true) {
-        await provider?.disconnect();
-      }
-
       const response = await provider?.connect();
       this._wallet = {
         address: response?.address,


### PR DESCRIPTION
Unclear why this change was made in the first place. If the wallet is disconnected on every connect then the user will be prompted everytime a dapp calls `connect`