### PR TITLE
Update blocto wallet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1979,9 +1979,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@blocto/sdk": {
-      "version": "0.3.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@blocto/sdk/-/sdk-0.3.0-beta.9.tgz",
-      "integrity": "sha512-B+7s/oYdS+TWhDkEc/06nmS+4T0VsVy5T2V3yOUxS2iPuqdNcwRNJtC40JzB+OmrxJrST6zOE8VbW9ved95VOg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@blocto/sdk/-/sdk-0.3.1.tgz",
+      "integrity": "sha512-vYZTq9QAgJyUQ15BljGhwVZzbrGLl1pEebRcLkoi7/UTyCsaU5p+oeVxyv1crCd8mARgbIcJGONdpOXLfpolaA==",
       "dependencies": {
         "bs58": "^4.0.1",
         "buffer": "^6.0.3",
@@ -1991,6 +1991,14 @@
       "peerDependencies": {
         "@solana/web3.js": "^1.30.2",
         "aptos": "^1.3.14"
+      },
+      "peerDependenciesMeta": {
+        "@solana/web3.js": {
+          "optional": true
+        },
+        "aptos": {
+          "optional": true
+        }
       }
     },
     "node_modules/@blocto/sdk/node_modules/buffer": {
@@ -4125,7 +4133,9 @@
           "type": "individual",
           "url": "https://paulmillr.com/funding/"
         }
-      ]
+      ],
+      "optional": true,
+      "peer": true
     },
     "node_modules/@noble/hashes": {
       "version": "1.1.3",
@@ -4147,7 +4157,9 @@
           "type": "individual",
           "url": "https://paulmillr.com/funding/"
         }
-      ]
+      ],
+      "optional": true,
+      "peer": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4875,6 +4887,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.0.tgz",
       "integrity": "sha512-lR0EMP2HC3+Mxwd4YcnZb0smnaDw7Bl2IQWZiTevRH5ZZBZn6VRWn3/92E3qdU4SSImJkA6IDHawOHAnx/qUvQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "buffer": "~6.0.3"
       },
@@ -4900,6 +4914,8 @@
           "url": "https://feross.org/support"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -4909,6 +4925,8 @@
       "version": "1.66.2",
       "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.66.2.tgz",
       "integrity": "sha512-RyaHMR2jGmaesnYP045VLeBGfR/gAW3cvZHzMFGg7bkO+WOYOYp1nEllf0/la4U4qsYGKCsO9eEevR5fhHiVHg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@noble/ed25519": "^1.7.0",
@@ -4948,6 +4966,8 @@
           "url": "https://feross.org/support"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -6956,6 +6976,8 @@
       "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
       "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
       "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "bindings": "^1.3.0"
       },
@@ -7001,6 +7023,8 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -7024,7 +7048,9 @@
     "node_modules/bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/body-parser": {
       "version": "1.20.1",
@@ -7098,6 +7124,8 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
       "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "bn.js": "^5.2.0",
         "bs58": "^4.0.0",
@@ -7216,6 +7244,7 @@
       "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
       "hasInstallScript": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -8752,6 +8781,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
       "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9139,6 +9170,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -9148,6 +9180,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -9333,12 +9366,16 @@
     "node_modules/es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "es6-promise": "^4.0.3"
       }
@@ -10363,6 +10400,8 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "> 0.1.90"
       }
@@ -10406,7 +10445,9 @@
     "node_modules/fast-stable-stringify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
-      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -10492,7 +10533,9 @@
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -12462,6 +12505,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "optional": true,
+      "peer": true,
       "peerDependencies": {
         "ws": "*"
       }
@@ -12556,6 +12601,8 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.7.0.tgz",
       "integrity": "sha512-tfy39KJMrrXJ+mFcMpxwBvFDetS8LAID93+rycFglIQM4kl3uNR3W4lBLE/FFhsoUCEox5Dt2adVpDm/XtebbQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/connect": "^3.4.33",
         "@types/node": "^12.12.54",
@@ -12581,12 +12628,16 @@
     "node_modules/jayson/node_modules/@types/node": {
       "version": "12.20.55",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jayson/node_modules/@types/ws": {
       "version": "7.4.7",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
       "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -12594,7 +12645,9 @@
     "node_modules/jayson/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jest": {
       "version": "27.5.1",
@@ -13683,7 +13736,8 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "devOptional": true
     },
     "node_modules/json2mq": {
       "version": "0.2.0",
@@ -13725,6 +13779,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "devOptional": true,
       "engines": [
         "node >= 0.2.0"
       ]
@@ -13741,6 +13796,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "devOptional": true,
       "dependencies": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -14921,6 +14977,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "devOptional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -19394,6 +19451,8 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.5.0.tgz",
       "integrity": "sha512-9tIRi1uZGy7YmDjErf1Ax3wtqdSSLIlnmL5OtOzgd5eqPKbsPpwDP5whUDO2LQay3Xp0CcHlcNSGzacNRluBaQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.2",
         "eventemitter3": "^4.0.7",
@@ -19413,6 +19472,8 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
       "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -20384,7 +20445,9 @@
     "node_modules/superstruct": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.14.2.tgz",
-      "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ=="
+      "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -20868,7 +20931,9 @@
     "node_modules/text-encoding-utf-8": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
-      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/text-extensions": {
       "version": "1.9.0",
@@ -20892,7 +20957,8 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "devOptional": true
     },
     "node_modules/through2": {
       "version": "4.0.2",
@@ -20982,7 +21048,8 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "devOptional": true
     },
     "node_modules/treeverse": {
       "version": "2.0.0",
@@ -21335,6 +21402,7 @@
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -21838,6 +21906,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "devOptional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -21846,7 +21915,8 @@
     "node_modules/whatwg-url/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "devOptional": true
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -22531,10 +22601,9 @@
       "name": "@manahippo/aptos-wallet-adapter",
       "version": "1.0.2",
       "dependencies": {
-        "@blocto/sdk": "^0.3.0-beta.9",
+        "@blocto/sdk": "^0.3.1",
         "@fewcha/web3": "0.1.32",
         "@keystonehq/aptossnap-adapter": "^0.2.8",
-        "@solana/web3.js": "^1.66.2",
         "eventemitter3": "^4.0.7",
         "js-sha3": "^0.8.0"
       },
@@ -25096,9 +25165,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@blocto/sdk": {
-      "version": "0.3.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@blocto/sdk/-/sdk-0.3.0-beta.9.tgz",
-      "integrity": "sha512-B+7s/oYdS+TWhDkEc/06nmS+4T0VsVy5T2V3yOUxS2iPuqdNcwRNJtC40JzB+OmrxJrST6zOE8VbW9ved95VOg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@blocto/sdk/-/sdk-0.3.1.tgz",
+      "integrity": "sha512-vYZTq9QAgJyUQ15BljGhwVZzbrGLl1pEebRcLkoi7/UTyCsaU5p+oeVxyv1crCd8mARgbIcJGONdpOXLfpolaA==",
       "requires": {
         "bs58": "^4.0.1",
         "buffer": "^6.0.3",
@@ -26523,10 +26592,9 @@
     "@manahippo/aptos-wallet-adapter": {
       "version": "file:packages/aptos-wallet-adapter",
       "requires": {
-        "@blocto/sdk": "^0.3.0-beta.9",
+        "@blocto/sdk": "^0.3.1",
         "@fewcha/web3": "0.1.32",
         "@keystonehq/aptossnap-adapter": "^0.2.8",
-        "@solana/web3.js": "^1.66.2",
         "@types/jest": "^27.0.1",
         "@types/node": "^18.7.6",
         "@types/react": "^18.0.17",
@@ -27528,7 +27596,9 @@
     "@noble/ed25519": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz",
-      "integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw=="
+      "integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==",
+      "optional": true,
+      "peer": true
     },
     "@noble/hashes": {
       "version": "1.1.3",
@@ -27538,7 +27608,9 @@
     "@noble/secp256k1": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
-      "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw=="
+      "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==",
+      "optional": true,
+      "peer": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -28082,6 +28154,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.0.tgz",
       "integrity": "sha512-lR0EMP2HC3+Mxwd4YcnZb0smnaDw7Bl2IQWZiTevRH5ZZBZn6VRWn3/92E3qdU4SSImJkA6IDHawOHAnx/qUvQ==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "buffer": "~6.0.3"
       },
@@ -28090,6 +28164,8 @@
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
           "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.2.1"
@@ -28101,6 +28177,8 @@
       "version": "1.66.2",
       "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.66.2.tgz",
       "integrity": "sha512-RyaHMR2jGmaesnYP045VLeBGfR/gAW3cvZHzMFGg7bkO+WOYOYp1nEllf0/la4U4qsYGKCsO9eEevR5fhHiVHg==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@noble/ed25519": "^1.7.0",
@@ -28123,6 +28201,8 @@
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.1.tgz",
           "integrity": "sha512-rVAXBwEcEoYtxnHSO5iWyhzV/O1WMtkUYWlfdLS7FjU4PnSJJHEfHXi/uHPI5EwltmOA794gN3bm3/pzuctWjQ==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.2.1"
@@ -29668,6 +29748,8 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
       "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "bindings": "^1.3.0"
       }
@@ -29703,6 +29785,8 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -29726,7 +29810,9 @@
     "bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "optional": true,
+      "peer": true
     },
     "body-parser": {
       "version": "1.20.1",
@@ -29792,6 +29878,8 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
       "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "bn.js": "^5.2.0",
         "bs58": "^4.0.0",
@@ -29873,6 +29961,7 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
       "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "node-gyp-build": "^4.3.0"
       }
@@ -31009,7 +31098,9 @@
     "delay": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
-      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw=="
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "optional": true,
+      "peer": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -31303,6 +31394,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "optional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
@@ -31312,6 +31404,7 @@
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "dev": true,
           "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -31463,12 +31556,16 @@
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "optional": true,
+      "peer": true
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -32208,7 +32305,9 @@
     "eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ=="
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "optional": true,
+      "peer": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -32246,7 +32345,9 @@
     "fast-stable-stringify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
-      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
+      "optional": true,
+      "peer": true
     },
     "fastq": {
       "version": "1.13.0",
@@ -32310,7 +32411,9 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true,
+      "peer": true
     },
     "filelist": {
       "version": "1.0.4",
@@ -33744,6 +33847,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "optional": true,
+      "peer": true,
       "requires": {}
     },
     "istanbul-lib-coverage": {
@@ -33814,6 +33919,8 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.7.0.tgz",
       "integrity": "sha512-tfy39KJMrrXJ+mFcMpxwBvFDetS8LAID93+rycFglIQM4kl3uNR3W4lBLE/FFhsoUCEox5Dt2adVpDm/XtebbQ==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "@types/connect": "^3.4.33",
         "@types/node": "^12.12.54",
@@ -33833,12 +33940,16 @@
         "@types/node": {
           "version": "12.20.55",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
+          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+          "optional": true,
+          "peer": true
         },
         "@types/ws": {
           "version": "7.4.7",
           "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
           "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "@types/node": "*"
           }
@@ -33846,7 +33957,9 @@
         "commander": {
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -34692,7 +34805,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "devOptional": true
     },
     "json2mq": {
       "version": "0.2.0",
@@ -34725,7 +34839,8 @@
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "devOptional": true
     },
     "jsonpointer": {
       "version": "5.0.1",
@@ -34736,6 +34851,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "devOptional": true,
       "requires": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -35622,6 +35738,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "devOptional": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -38713,6 +38830,8 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.5.0.tgz",
       "integrity": "sha512-9tIRi1uZGy7YmDjErf1Ax3wtqdSSLIlnmL5OtOzgd5eqPKbsPpwDP5whUDO2LQay3Xp0CcHlcNSGzacNRluBaQ==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.17.2",
         "bufferutil": "^4.0.1",
@@ -38726,6 +38845,8 @@
           "version": "8.10.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
           "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+          "optional": true,
+          "peer": true,
           "requires": {}
         }
       }
@@ -39449,7 +39570,9 @@
     "superstruct": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.14.2.tgz",
-      "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ=="
+      "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ==",
+      "optional": true,
+      "peer": true
     },
     "supports-color": {
       "version": "7.2.0",
@@ -39816,7 +39939,9 @@
     "text-encoding-utf-8": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
-      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==",
+      "optional": true,
+      "peer": true
     },
     "text-extensions": {
       "version": "1.9.0",
@@ -39837,7 +39962,8 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "devOptional": true
     },
     "through2": {
       "version": "4.0.2",
@@ -39911,7 +40037,8 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "devOptional": true
     },
     "treeverse": {
       "version": "2.0.0",
@@ -40169,6 +40296,7 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "optional": true,
+      "peer": true,
       "requires": {
         "node-gyp-build": "^4.3.0"
       }
@@ -40545,6 +40673,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "devOptional": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -40553,7 +40682,8 @@
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "devOptional": true
         }
       }
     },

--- a/packages/aptos-wallet-adapter/README.md
+++ b/packages/aptos-wallet-adapter/README.md
@@ -77,7 +77,7 @@ const wallets = [
   new FletchWalletAdapter(),
   new TokenPocketWalletAdapter(),
   new ONTOWalletAdapter(),
-  new BloctoWalletAdapter(),
+  new BloctoWalletAdapter({ bloctoAppId:'6d85f56e-5f2e-46cd-b5f2-5cf9695b4d46' }), /** Must provide bloctoAppId **/
   new SafePalWalletAdapter(),
   new FoxWalletAdapter(),
 ];

--- a/packages/aptos-wallet-adapter/package.json
+++ b/packages/aptos-wallet-adapter/package.json
@@ -28,10 +28,9 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@blocto/sdk": "^0.3.0-beta.9",
+    "@blocto/sdk": "^0.3.1",
     "@fewcha/web3": "0.1.32",
     "@keystonehq/aptossnap-adapter": "^0.2.8",
-    "@solana/web3.js": "^1.66.2",
     "eventemitter3": "^4.0.7",
     "js-sha3": "^0.8.0"
   }

--- a/packages/aptos-wallet-adapter/src/WalletAdapters/BloctoWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/BloctoWallet.ts
@@ -26,9 +26,9 @@ export const BloctoWalletName = 'Blocto' as WalletName<'Blocto'>;
 
 export interface BloctoWalletAdapterConfig {
   provider?: IBloctoAptos;
-  network: Exclude<WalletAdapterNetwork, WalletAdapterNetwork.Devnet>;
+  network?: Exclude<WalletAdapterNetwork, WalletAdapterNetwork.Devnet>;
   timeout?: number;
-  bloctoAppId?: string;
+  bloctoAppId: string;
 }
 
 export const APTOS_NETWORK_CHAIN_ID_MAPPING = {
@@ -64,11 +64,11 @@ export class BloctoWalletAdapter extends BaseWalletAdapter {
 
   protected _wallet: any | null;
 
-  constructor(
-    { network, timeout = 10000, bloctoAppId = '' }: BloctoWalletAdapterConfig = {
-      network: WalletAdapterNetwork.Testnet
-    }
-  ) {
+  constructor({
+    network = WalletAdapterNetwork.Mainnet,
+    timeout = 10000,
+    bloctoAppId
+  }: BloctoWalletAdapterConfig) {
     super();
 
     const sdk = new BloctoSDK({

--- a/packages/wallet-nextjs/pages/_app.tsx
+++ b/packages/wallet-nextjs/pages/_app.tsx
@@ -37,7 +37,7 @@ function MyApp({ Component, pageProps }: AppProps) {
       new NightlyWalletAdapter(),
       new BitkeepWalletAdapter(),
       new TokenPocketWalletAdapter(),
-      new BloctoWalletAdapter({ network:WalletAdapterNetwork.Testnet }),
+      new BloctoWalletAdapter({ network: WalletAdapterNetwork.Testnet, bloctoAppId:'6d85f56e-5f2e-46cd-b5f2-5cf9695b4d46' }),
       new Coin98WalletAdapter(),
       new FoxWalletAdapter()
     ],

--- a/packages/wallet-tester/src/App.tsx
+++ b/packages/wallet-tester/src/App.tsx
@@ -48,7 +48,10 @@ const App: React.FC = () => {
       new NightlyWalletAdapter(),
       new BitkeepWalletAdapter(),
       new TokenPocketWalletAdapter(),
-      new BloctoWalletAdapter({ network: WalletAdapterNetwork.Testnet }),
+      new BloctoWalletAdapter({
+        network: WalletAdapterNetwork.Testnet,
+        bloctoAppId: 'f7e52efa-18c4-4984-981f-ef6da6837652'
+      }),
       new ONTOWalletAdapter(),
       new FoxWalletAdapter()
     ],


### PR DESCRIPTION
- Update `@blocto/sdk` version and remove `@solana/web3.js` as the dependency
  - `@blocto/sdk` is updated to mark `@solana/web3.js` as an optional peer dependency. This way, it allows developers to decide whether to install the package on their own, and not getting the compiling error when they don't include it.
- Update the default network for Blocto wallet to be `mainnet`
- Also update Blocto wallet adapter to initialize with `bloctoAppId` as a requirement