### PR TITLE
Fix for Petra emitting the public key instead of address

### DIFF
--- a/packages/aptos-wallet-adapter/src/WalletAdapters/PetraWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/PetraWallet.ts
@@ -175,7 +175,7 @@ export class AptosWalletAdapter extends BaseWalletAdapter {
         throw error;
       }
 
-      this.emit('connect', this._wallet.publicKey);
+      this.emit('connect', this._wallet.address);
     } catch (error: any) {
       this.emit('error', error);
       throw error;


### PR DESCRIPTION
Other wallets are emitting the address, this is confusing for dapps.

I'm ok with just emitting the address but seems to be a mismatch with what the interface expects. Might want to update the interface there - https://github.com/hippospace/aptos-wallet-adapter/blob/30258e351c304408cc52c0371f36a952b2ac4aed/packages/aptos-wallet-adapter/src/WalletAdapters/BaseAdapter.ts#L24

The base adapter expects the public key to be emitted.