### PR TITLE
Support MSafe allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Supports:
 - [Nightly Wallet](https://nightly.app/download)
 - [OpenBlock Wallet](https://openblock.com)
 - [Spacecy wallet](https://spacecywallet.com/)
+- [Msafe wallet](https://app.m-safe.io)
 
 **Please refer to the readme within aptos-wallet-adapter pacakages**
 
@@ -53,3 +54,4 @@ Automatically testing suites based on puppeteer to run E2E integration tests aga
 | Blocto  | F(cannot test)         | F(cannot test)               |
 | BitKeep | F                      | F                            |
 | Spacecy | T                      | T                            |
+| Msafe   | T(cannot test)         | T(cannot test)               |

--- a/packages/aptos-wallet-adapter/package.json
+++ b/packages/aptos-wallet-adapter/package.json
@@ -34,6 +34,6 @@
     "@openblockhq/dappsdk": "^5.0.2",
     "eventemitter3": "^4.0.7",
     "js-sha3": "^0.8.0",
-    "msafe-wallet": "2.0.x"
+    "msafe-wallet": "^2.0.5"
   }
 }

--- a/packages/aptos-wallet-adapter/package.json
+++ b/packages/aptos-wallet-adapter/package.json
@@ -34,6 +34,6 @@
     "@openblockhq/dappsdk": "^5.0.2",
     "eventemitter3": "^4.0.7",
     "js-sha3": "^0.8.0",
-    "msafe-wallet": "^1.1.9"
+    "msafe-wallet": "2.0.x"
   }
 }

--- a/packages/aptos-wallet-adapter/src/WalletAdapters/MsafeWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/MsafeWallet.ts
@@ -26,8 +26,9 @@ export const MsafeWalletName = 'Msafe' as WalletName<'Msafe'>;
 
 interface MsafeAccount {
   address: MaybeHexString;
-  publicKey: MaybeHexString;
+  publicKey: MaybeHexString[];
   authKey: MaybeHexString;
+  minKeysRequired: number;
   isConnected: boolean;
 }
 
@@ -72,9 +73,10 @@ export class MsafeWalletAdapter extends BaseWalletAdapter {
 
   get publicAccount(): AccountKeys {
     return {
-      publicKey: this._wallet?.publicKey || null,
-      address: this._wallet?.address || null,
-      authKey: this._wallet?.authKey || null
+      publicKey: this._wallet?.publicKey,
+      address: this._wallet?.address,
+      authKey: this._wallet?.authKey,
+      minKeysRequired: this._wallet?.minKeysRequired
     };
   }
 


### PR DESCRIPTION
This pr is based on #110. It changes the argument type of the MsafeWalletAdapter constructor to fit msafe's allowlist. 