### PR TITLE
upgrade msafe-wallet to v2.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Supports:
 - [Nightly Wallet](https://nightly.app/download)
 - [OpenBlock Wallet](https://openblock.com)
 - [Spacecy wallet](https://spacecywallet.com/)
-- [Msafe wallet](https://app.m-safe.io)
+- [MSafe wallet](https://app.m-safe.io)
 
 **Please refer to the readme within aptos-wallet-adapter pacakages**
 
@@ -54,4 +54,4 @@ Automatically testing suites based on puppeteer to run E2E integration tests aga
 | Blocto  | F(cannot test)         | F(cannot test)               |
 | BitKeep | F                      | F                            |
 | Spacecy | T                      | T                            |
-| Msafe   | T(cannot test)         | T(cannot test)               |
+| MSafe   | T(cannot test)         | T(cannot test)               |

--- a/packages/aptos-wallet-adapter/package.json
+++ b/packages/aptos-wallet-adapter/package.json
@@ -34,6 +34,6 @@
     "@openblockhq/dappsdk": "^5.0.2",
     "eventemitter3": "^4.0.7",
     "js-sha3": "^0.8.0",
-    "msafe-wallet": "2.1.x"
+    "msafe-wallet": "~2.1.3"
   }
 }

--- a/packages/aptos-wallet-adapter/package.json
+++ b/packages/aptos-wallet-adapter/package.json
@@ -34,6 +34,6 @@
     "@openblockhq/dappsdk": "^5.0.2",
     "eventemitter3": "^4.0.7",
     "js-sha3": "^0.8.0",
-    "msafe-wallet": "2.0.x"
+    "msafe-wallet": "^2.0.5"
   }
 }

--- a/packages/aptos-wallet-adapter/package.json
+++ b/packages/aptos-wallet-adapter/package.json
@@ -34,6 +34,6 @@
     "@openblockhq/dappsdk": "^5.0.2",
     "eventemitter3": "^4.0.7",
     "js-sha3": "^0.8.0",
-    "msafe-wallet": "^2.0.5"
+    "msafe-wallet": "2.1.x"
   }
 }

--- a/packages/aptos-wallet-adapter/src/WalletAdapters/MSafeWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/MSafeWallet.ts
@@ -271,6 +271,10 @@ export class MSafeWalletAdapter extends BaseWalletAdapter {
 }
 
 /**
+ * @deprecated Use `MSafeWalletName` instead.
+ */
+export const MsafeWalletName = MSafeWalletName;
+/**
  * @deprecated Use `MsafeWalletAdapter` instead.
  */
 export class MsafeWalletAdapter extends MSafeWalletAdapter {}

--- a/packages/aptos-wallet-adapter/src/WalletAdapters/MSafeWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/MSafeWallet.ts
@@ -84,7 +84,7 @@ export class MSafeWalletAdapter extends BaseWalletAdapter {
         .catch((e) => {
           this._readyState = WalletReadyState.Unsupported;
           this.emit('readyStateChange', this._readyState);
-          console.log(e);
+          console.error('MSafe connect error:', e);
         });
     }
   }

--- a/packages/aptos-wallet-adapter/src/WalletAdapters/MSafeWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/MSafeWallet.ts
@@ -273,4 +273,4 @@ export class MSafeWalletAdapter extends BaseWalletAdapter {
 /**
  * @deprecated Use `MsafeWalletAdapter` instead.
  */
-export const MsafeWalletAdapter = MSafeWalletAdapter;
+export class MsafeWalletAdapter extends MSafeWalletAdapter {}

--- a/packages/aptos-wallet-adapter/src/WalletAdapters/MSafeWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/MSafeWallet.ts
@@ -89,6 +89,7 @@ export class MSafeWalletAdapter extends BaseWalletAdapter {
     }
   }
 
+  /// fix issue of next.js: access url via getter to avoid access window object in constructor
   get url() {
     return MSafeWallet.getAppUrl(this._origin instanceof Array ? this._origin[0] : this._origin);
   }

--- a/packages/aptos-wallet-adapter/src/WalletAdapters/MSafeWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/MSafeWallet.ts
@@ -20,11 +20,11 @@ import {
   WalletName,
   WalletReadyState
 } from './BaseAdapter';
-import { Account, MsafeWallet } from 'msafe-wallet';
+import { Account, MSafeWallet } from 'msafe-wallet';
 
-export const MsafeWalletName = 'Msafe' as WalletName<'Msafe'>;
+export const MSafeWalletName = 'MSafe' as WalletName<'MSafe'>;
 
-interface MsafeAccount {
+interface MSafeAccount {
   address: MaybeHexString;
   publicKey: MaybeHexString[];
   authKey: MaybeHexString;
@@ -32,25 +32,25 @@ interface MsafeAccount {
   isConnected: boolean;
 }
 
-export class MsafeWalletAdapter extends BaseWalletAdapter {
-  name = MsafeWalletName;
+export class MSafeWalletAdapter extends BaseWalletAdapter {
+  name = MSafeWalletName;
 
   icon = 'https://raw.githubusercontent.com/hippospace/aptos-wallet-adapter/main/logos/msafe.png';
 
-  protected _provider: MsafeWallet | undefined;
+  protected _provider: MSafeWallet | undefined;
 
   protected _network: WalletAdapterNetwork;
 
   protected _chainId: string;
 
-  // MsafeWallet only works in msafe appstore iframe
-  protected _readyState: WalletReadyState = MsafeWallet.inMsafeWallet()
+  // MSafeWallet only works in msafe appstore iframe
+  protected _readyState: WalletReadyState = MSafeWallet.inMSafeWallet()
     ? WalletReadyState.NotDetected
     : WalletReadyState.Unsupported;
 
   protected _connecting: boolean;
 
-  protected _wallet: MsafeAccount | null;
+  protected _wallet: MSafeAccount | null;
 
   private _origin?: string | string[];
 
@@ -60,7 +60,7 @@ export class MsafeWalletAdapter extends BaseWalletAdapter {
     this._connecting = false;
     this._origin = origin;
     if (this._readyState === WalletReadyState.NotDetected) {
-      MsafeWallet.new(origin)
+      MSafeWallet.new(origin)
         .then((msafe) => {
           this._provider = msafe;
           this._readyState = WalletReadyState.Installed;
@@ -75,7 +75,7 @@ export class MsafeWalletAdapter extends BaseWalletAdapter {
   }
 
   get url() {
-    return MsafeWallet.getAppUrl(this._origin instanceof Array ? this._origin[0] : this._origin);
+    return MSafeWallet.getAppUrl(this._origin instanceof Array ? this._origin[0] : this._origin);
   }
 
   get publicAccount(): AccountKeys {
@@ -269,3 +269,8 @@ export class MsafeWalletAdapter extends BaseWalletAdapter {
     }
   }
 }
+
+/**
+ * @deprecated Use `MsafeWalletAdapter` instead.
+ */
+export const MsafeWalletAdapter = MSafeWalletAdapter;

--- a/packages/aptos-wallet-adapter/src/WalletAdapters/MSafeWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/MSafeWallet.ts
@@ -54,6 +54,21 @@ export class MSafeWalletAdapter extends BaseWalletAdapter {
 
   private _origin?: string | string[];
 
+  /**
+   * @description create a MSafeWalletAdapter
+   * @param origin allowlist of msafe website url, omit means accpets all msafe websites. you can pass a single url or an array of urls.
+   * @example
+   *  // 1. Initialize MSafeWalletAdapter with default allowlist:
+   *      new MSafeWalletAdapter();
+   *  // 2. Initialize MSafeWalletAdapter with a single MSafe url:
+   *      new MSafeWalletAdapter('https://app.m-safe.io');
+   *  // 3. Initialize MSafeWalletAdapter with an array of MSafe urls:
+   *      new MSafeWalletAdapter(['https://app.m-safe.io', 'https://testnet.m-safe.io', 'https://partner.m-safe.io']);
+   *  // 4. Initialize MSafeWalletAdapter with a single network type:
+   *      new MSafeWalletAdapter('Mainnet');
+   *  // 5. Initialize MSafeWalletAdapter with an array of network types:
+   *      new MSafeWalletAdapter(['Mainnet', 'Testnet', 'Partner']);
+   */
   constructor(origin?: string | string[]) {
     super();
     this._network = undefined;
@@ -275,6 +290,6 @@ export class MSafeWalletAdapter extends BaseWalletAdapter {
  */
 export const MsafeWalletName = MSafeWalletName;
 /**
- * @deprecated Use `MsafeWalletAdapter` instead.
+ * @deprecated Use `MSafeWalletAdapter` instead.
  */
 export class MsafeWalletAdapter extends MSafeWalletAdapter {}

--- a/packages/aptos-wallet-adapter/src/WalletAdapters/index.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/index.ts
@@ -18,7 +18,7 @@ export * from './BloctoWallet';
 export * from './Coin98Wallet';
 export * from './SafePalWallet';
 export * from './FoxWallet';
-export * from './MsafeWallet';
+export * from './MSafeWallet';
 export * from './OpenBlockWallet';
 export * from './CloverWallet';
 export * from './SpacecyWallet';


### PR DESCRIPTION
This PR includes #111 and #112.
Changes:
1. support allowlist of msafe-wallet
     - #111 
     - https://github.com/Momentum-Safe/msafe-wallet/pull/17
2. rename 'MsafeXXX' to 'MSafeXXX'
     - #112
     - https://github.com/Momentum-Safe/msafe-wallet/pull/19
3. use msafe-wallet ~2.1.3