### PR TITLE
fix: TypeError when auto-locking Fewcha

### DIFF
--- a/packages/aptos-wallet-adapter/src/WalletAdapters/FewchaWallet.ts
+++ b/packages/aptos-wallet-adapter/src/WalletAdapters/FewchaWallet.ts
@@ -145,7 +145,7 @@ export class FewchaWalletAdapter extends BaseWalletAdapter {
 
       if (!accountDetail.publicKey) {
         const accountResp = await provider.account();
-        if (!accountResp.data.publicKey) {
+        if (!accountResp?.data?.publicKey) {
           throw new WalletConnectionError('Wallet connect issue', response.data);
         }
         accountDetail = { ...accountResp.data };


### PR DESCRIPTION
## Description
The adapter works fine when the user manually locks the Fewcha, but the [`accountResp`](https://github.com/hippospace/aptos-wallet-adapter/pull/118/files#diff-2dbff4c2786efdcd13c922e58cb27abaf41411a07b6d69c0fa5ede837c10215eL148) will be undefined when Fewcha locks itself after `Time Lock`, and you can set the `Time Lock` to 1 minute for faster testing. 

## Screen Recoding:
Can jump to 1:10 to see the TypeError.

https://github.com/hippospace/aptos-wallet-adapter/assets/125171539/eb1125d8-01fa-4f23-9b6a-b9930ce9a52e


CodeSandbox Link: https://codesandbox.io/s/pedantic-torvalds-gw3z3f?file=/src/Page.tsx:365-385